### PR TITLE
Fix entrance animations leaving content invisible

### DIFF
--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -8,7 +8,7 @@ if (article) {
 	animate(
 		children,
 		{
-			transform: ["translate(0, 2rem) scale(0.8)", "none"],
+			transform: ["translate(0, 2rem) scale(0.8)", "translate(0, 0) scale(1)"],
 			opacity: [null, 1],
 		},
 		{ delay: stagger(0.02, { ease: "easeOut" }), duration: 0.35 }
@@ -23,7 +23,7 @@ if (gallery) {
 	animate(
 		children,
 		{
-			transform: ["translate(0, 2rem)", "none"],
+			transform: ["translate(0, 2rem)", "translate(0, 0)"],
 			opacity: [null, 1],
 		},
 		{ delay: stagger(0.04, { ease: "easeOut" }), duration: 0.35 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Article content was invisible after page load. Elements started at `opacity: 0` and the client animation ran, but finished with `transform: matrix(0, 0, 0, 0, 0, 0)` (scale 0) even though opacity reached 1.

This happened because Motion v12 does not resolve the transform end value `"none"` correctly when the start value includes `scale(0.8)`.

## Fix

Use explicit end transform values instead of `"none"`:

- Article: `"translate(0, 0) scale(1)"`
- Gallery: `"translate(0, 0)"`

## Testing

- Ran `npm run dev` and verified at http://localhost:3000
- Confirmed homepage, blog, and projects pages show content after animation completes (no zero-size elements)
- Verified transforms end at identity matrix and opacity is 1
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d31fde19-e533-4963-9f6d-505a384ca918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d31fde19-e533-4963-9f6d-505a384ca918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

